### PR TITLE
2:1 balanced tree feature

### DIFF
--- a/include/args.h
+++ b/include/args.h
@@ -10,8 +10,9 @@ namespace exafmm_t {
   static struct option long_options[] = {
     {"ncrit",        required_argument, 0, 'c'},
     {"numBodies",    required_argument, 0, 'n'},
-    {"P",           required_argument, 0, 'P'},
+    {"P",            required_argument, 0, 'P'},
     {"threads",      required_argument, 0, 'T'},
+    {"distribution", required_argument, 0, 'd'},
     {0, 0, 0, 0}
   };
 
@@ -21,6 +22,7 @@ namespace exafmm_t {
     int numBodies;
     int P;
     int threads;
+    const char * distribution;
 
   private:
     void usage(char * name) {
@@ -28,14 +30,27 @@ namespace exafmm_t {
 	      "Usage: %s [options]\n"
 	      "Long option (short option)     : Description (Default value)\n"
 	      " --ncrit (-c)                  : Number of bodies per leaf node (%d)\n"
+              " --distribution (-d) [c/p]     : cube, plummer (%s)\n"
 	      " --numBodies (-n)              : Number of bodies (%d)\n"
 	      " --P (-P)                      : Order of expansion (%d)\n"
 	      " --threads (-T)                : Number of threads (%d)\n",
 	      name,
 	      ncrit,
+              distribution,
 	      numBodies,
 	      P,
 	      threads);
+    }
+
+    const char * parseDistribution(const char * arg) {
+      switch (arg[0]) {
+        case 'c': return "cube";
+        case 'p': return "plummer";
+        default:
+          fprintf(stderr, "invalid distribution %s\n", arg);
+          abort();
+      }
+      return "";
     }
 
   public:
@@ -43,7 +58,8 @@ namespace exafmm_t {
       ncrit(64),
       numBodies(1000000),
       P(4),
-      threads(16) {
+      threads(16),
+      distribution("cube") {
       while (1) {
 	int option_index;
 	int c = getopt_long(argc, argv, "c:d:DgGhi:jmn:oP:r:s:t:T:vwx", long_options, &option_index);
@@ -52,6 +68,9 @@ namespace exafmm_t {
 	case 'c':
 	  ncrit = atoi(optarg);
 	  break;
+        case 'd':
+          distribution = parseDistribution(optarg);
+          break;
 	case 'n':
 	  numBodies = atoi(optarg);
 	  break;
@@ -71,6 +90,8 @@ namespace exafmm_t {
     void print(int stringLength, int P) {
       std::cout << std::setw(stringLength) << std::fixed << std::left
                 << "ncrit" << " : " << ncrit << std::endl
+                << std::setw(stringLength)
+                << "distribution" << " : " << distribution << std::endl
                 << std::setw(stringLength)
                 << "numBodies" << " : " << numBodies << std::endl
                 << std::setw(stringLength)

--- a/include/build_tree.h
+++ b/include/build_tree.h
@@ -1,6 +1,7 @@
 #ifndef buildtree_h
 #define buildtree_h
 #include "exafmm_t.h"
+#include "hilbert.h"
 
 namespace exafmm_t {
   //! Build nodes of tree adaptively using a top-down approach based on recursion

--- a/include/build_tree.h
+++ b/include/build_tree.h
@@ -24,7 +24,7 @@ namespace exafmm_t {
     ivec3 iX = get3DIndex(X, level);
     node->key = getKey(iX, level);
     //! Count number of bodies in each octant
-    int size[8] = {0,0,0,0,0,0,0,0};
+    int size[8] = {0};
     vec3 x;
     for (int i=begin; i<end; i++) {
       x = bodies[i].X;
@@ -37,7 +37,6 @@ namespace exafmm_t {
     for (int i=0; i<8; i++) {
       offsets[i] = offset;
       offset += size[i];
-      if (size[i]) node->numChilds++;
     }
     //! If node is a leaf
     if (end - begin <= args.ncrit) {
@@ -63,6 +62,7 @@ namespace exafmm_t {
       counter[octant]++;
     }
     //! Loop over children and recurse
+    node->numChilds = 8;
     vec3 Xchild;
     assert(nodes.capacity() >= nodes.size()+node->numChilds);
     nodes.resize(nodes.size()+node->numChilds);
@@ -75,14 +75,12 @@ namespace exafmm_t {
       for (int d=0; d<3; d++) {
         Xchild[d] += Rchild * (((i & 1 << d) >> d) * 2 - 1);
       }
-      if (size[i]) {
-        child[c].parent = node;
-        child[c].octant = i;
-        node->child[i] = &child[c];
-        buildTree(buffer, bodies, offsets[i], offsets[i] + size[i],
-                  &child[c++], nodes, Xchild, Rchild, leafs, nonleafs,
-                  args, level+1, !direction);
-      }
+      child[c].parent = node;
+      child[c].octant = i;
+      node->child[i] = &child[c];
+      buildTree(buffer, bodies, offsets[i], offsets[i] + size[i],
+                &child[c++], nodes, Xchild, Rchild, leafs, nonleafs,
+                args, level+1, !direction);
     }
   }
 

--- a/include/build_tree.h
+++ b/include/build_tree.h
@@ -19,6 +19,8 @@ namespace exafmm_t {
     node->R = R;
     node->upward_equiv.resize(NSURF, 0.0);
     node->dnward_equiv.resize(NSURF, 0.0);
+    ivec3 iX = get3DIndex(X, level);
+    node->key = getKey(iX, level);
     //! Count number of bodies in each octant
     int size[8] = {0,0,0,0,0,0,0,0};
     vec3 x;

--- a/include/build_tree.h
+++ b/include/build_tree.h
@@ -9,7 +9,7 @@ namespace exafmm_t {
   //! Build nodes of tree adaptively using a top-down approach based on recursion
   void buildTree(Body * bodies, Body * buffer, int begin, int end, Node * node, Nodes & nodes,
                  const vec3 & X, real_t R, std::vector<Node*> & leafs, std::vector<Node*> & nonleafs,
-                 Args & args, int level=0, bool direction=false) {
+                 Args & args, const Keys & leafkeys, int level=0, bool direction=false) {
     node->depth = level;         // depth
     node->idx = int(node-&nodes[0]);  // current node's index in nodes
     //! Create a tree node
@@ -39,7 +39,14 @@ namespace exafmm_t {
       offset += size[i];
     }
     //! If node is a leaf
-    if (end - begin <= args.ncrit) {
+    bool isLeafKey = 1;
+    if (!leafkeys.empty()) {  // when leafkeys is given (when balancing tree) 
+      std::set<uint64_t>::iterator it = leafkeys[level].find(node->key);
+      if (it == leafkeys[level].end()) {  // if current key is not a leaf key
+        isLeafKey = 0;
+      }
+    }
+    if (end-begin<=args.ncrit && isLeafKey) {
       node->numChilds = 0;
       node->pt_trg.resize(node->numBodies*4);   // initialize target result vector
       leafs.push_back(node);
@@ -80,11 +87,11 @@ namespace exafmm_t {
       node->child[i] = &child[c];
       buildTree(buffer, bodies, offsets[i], offsets[i] + size[i],
                 &child[c++], nodes, Xchild, Rchild, leafs, nonleafs,
-                args, level+1, !direction);
+                args, leafkeys, level+1, !direction);
     }
   }
 
-  Nodes buildTree(Bodies & bodies, std::vector<Node*> & leafs, std::vector<Node*> & nonleafs, Args & args) {
+  Nodes buildTree(Bodies & bodies, std::vector<Node*> & leafs, std::vector<Node*> & nonleafs, Args & args, const Keys & leafkeys=Keys()) {
     real_t R0 = 0.5;
     vec3 X0(0.5);
     Bodies buffer = bodies;
@@ -92,7 +99,7 @@ namespace exafmm_t {
     nodes[0].parent = NULL;
     nodes[0].octant = 0;
     nodes.reserve(bodies.size()*(32/args.ncrit+1));
-    buildTree(&bodies[0], &buffer[0], 0, bodies.size(), &nodes[0], nodes, X0, R0, leafs, nonleafs, args);
+    buildTree(&bodies[0], &buffer[0], 0, bodies.size(), &nodes[0], nodes, X0, R0, leafs, nonleafs, args, leafkeys);
     return nodes;
   }
 

--- a/include/dataset.h
+++ b/include/dataset.h
@@ -71,5 +71,20 @@ namespace exafmm_t {
     }
     return bodies;
   }
+
+  Bodies initBodies(int numBodies, const char * distribution, int seed) {
+    Bodies bodies;
+    switch (distribution[0]) {
+      case 'c':
+        bodies = cube(numBodies, seed);
+        break;
+      case 'p':
+        bodies = plummer(numBodies, seed);
+        break;
+      default:
+        fprintf(stderr, "Unknown data distribution %s\n", distribution);
+    }
+    return bodies;
+  }
 }
 #endif

--- a/include/exafmm_t.h
+++ b/include/exafmm_t.h
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <fftw3.h>
 #include <iostream>
+#include <set>
 #include <vector>
 #include "align.h"
 #include "args.h"
@@ -76,6 +77,7 @@ namespace exafmm_t {
     Body * body;
     vec3 X;
     real_t R;
+    uint64_t key;
 
     size_t idx;
     size_t node_id;
@@ -101,6 +103,7 @@ namespace exafmm_t {
     }
   };
   typedef std::vector<Node> Nodes;              //!< Vector of nodes
+  typedef std::vector<std::set<uint64_t>> Keys; //!< Vector of Morton keys of each level
 
   struct M2LData {
     std::vector<size_t> fft_vec;   // source's first child's upward_equiv's displacement

--- a/include/hilbert.h
+++ b/include/hilbert.h
@@ -1,0 +1,159 @@
+#ifndef hilbert_h
+#define hilbert_h
+#include <cstdlib>
+#include <stdint.h>
+#include "exafmm_t.h"
+#define EXAFMM_HILBERT 0 //! Set this to 1 for Hilbert
+
+namespace exafmm_t {
+  //! Levelwise offset of Hilbert key
+  inline uint64_t levelOffset(int level) {
+    return (((uint64_t)1 << 3 * level) - 1) / 7;
+  }
+
+  //! Get level from Hilbert key
+  int getLevel(uint64_t i) {
+    int level = -1;
+    uint64_t offset = 0;
+    while (i >= offset) {
+      level++;
+      offset += (uint64_t)1 << 3 * level;
+    }
+    return level;
+  }
+
+  //! Get parent's Hilbert key
+  uint64_t getParent(uint64_t i) {
+    int level = getLevel(i);
+    return (i - levelOffset(level)) / 8 + levelOffset(level-1);
+  }
+
+  //! Get first child's Hilbert key
+  uint64_t getChild(uint64_t i) {
+    int level = getLevel(i);
+    return (i - levelOffset(level)) * 8 + levelOffset(level+1);
+  }
+
+  //! Determine which octant the key belongs to
+  int getOctant(uint64_t key, bool offset=true) {
+    int level = getLevel(key);
+    if (offset) key -= levelOffset(level);
+    return key & 7;
+  }
+
+  //! Get Hilbert key from 3-D index
+  uint64_t getKey(ivec3 iX, int level, bool offset=true) {
+#if EXAFMM_HILBERT
+    int M = 1 << (level - 1);
+    for (int Q=M; Q>1; Q>>=1) {
+      int R = Q - 1;
+      for (int d=0; d<3; d++) {
+        if (iX[d] & Q) iX[0] ^= R;
+        else {
+          int t = (iX[0] ^ iX[d]) & R;
+          iX[0] ^= t;
+          iX[d] ^= t;
+        }
+      }
+    }
+    for (int d=1; d<3; d++) iX[d] ^= iX[d-1];
+    int t = 0;
+    for (int Q=M; Q>1; Q>>=1)
+      if (iX[2] & Q) t ^= Q - 1;
+    for (int d=0; d<3; d++) iX[d] ^= t;
+#endif
+    uint64_t i = 0;
+    for (int l=0; l<level; l++) {
+      i |= (iX[2] & (uint64_t)1 << l) << 2*l;
+      i |= (iX[1] & (uint64_t)1 << l) << (2*l + 1);
+      i |= (iX[0] & (uint64_t)1 << l) << (2*l + 2);
+    }
+    if (offset) i += levelOffset(level);
+    return i;
+  }
+
+  //! Get 3-D index from Hilbert key
+  ivec3 get3DIndex(uint64_t i) {
+    int level = getLevel(i);
+    i -= levelOffset(level);
+    ivec3 iX = 0;
+    for (int l=0; l<level; l++) {
+      iX[2] |= (i & (uint64_t)1 << 3*l) >> 2*l;
+      iX[1] |= (i & (uint64_t)1 << (3*l + 1)) >> (2*l + 1);
+      iX[0] |= (i & (uint64_t)1 << (3*l + 2)) >> (2*l + 2);
+    }
+#if EXAFMM_HILBERT
+    int N = 2 << (level - 1);
+    int t = iX[2] >> 1;
+    for (int d=2; d>0; d--) iX[d] ^= iX[d-1];
+    iX[0] ^= t;
+    for (int Q=2; Q!=N; Q<<=1) {
+      int R = Q - 1;
+      for (int d=2; d>=0; d--) {
+        if (iX[d] & Q) iX[0] ^= R;
+        else {
+          t = (iX[0] ^ iX[d]) & R;
+          iX[0] ^= t;
+          iX[d] ^= t;
+        }
+      }
+    }
+#endif
+    return iX;
+  }
+
+  //! Get 3-D index from Hilbert key without level offset
+  ivec3 get3DIndex(uint64_t i, int level) {
+    ivec3 iX = 0;
+    for (int l=0; l<level; l++) {
+      iX[2] |= (i & (uint64_t)1 << 3*l) >> 2*l;
+      iX[1] |= (i & (uint64_t)1 << (3*l + 1)) >> (2*l + 1);
+      iX[0] |= (i & (uint64_t)1 << (3*l + 2)) >> (2*l + 2);
+    }
+#if EXAFMM_HILBERT
+    int N = 2 << (level - 1);
+    int t = iX[2] >> 1;
+    for (int d=2; d>0; d--) iX[d] ^= iX[d-1];
+    iX[0] ^= t;
+    for (int Q=2; Q!=N; Q<<=1) {
+      int R = Q - 1;
+      for (int d=2; d>=0; d--) {
+        if (iX[d] & Q) iX[0] ^= R;
+        else {
+          t = (iX[0] ^ iX[d]) & R;
+          iX[0] ^= t;
+          iX[d] ^= t;
+        }
+      }
+    }
+#endif
+    return iX;
+  }
+
+  //! Get 3-D index from coordinates
+  ivec3 get3DIndex(vec3 X, int level) {
+    real_t X0 = 0.5;
+    real_t R0 = 0.5;
+    vec3 Xmin = X0 - R0;
+    real_t dx = 2 * R0 / (1 << level);
+    ivec3 iX;
+    for (int d=0; d<3; d++) {
+      iX[d] = floor((X[d] - Xmin[d]) / dx);
+    }
+    return iX;
+  }
+
+  //! Get coordinates from 3-D index
+  vec3 getCoordinates(ivec3 iX, int level) {
+    real_t X0 = 0.5;
+    real_t R0 = 0.5;
+    vec3 Xmin = X0 - R0;
+    real_t dx = 2 * R0 / (1 << level);
+    vec3 X;
+    for (int d=0; d<3; d++) {
+      X[d] = (iX[d] + 0.5) * dx + Xmin[d];
+    }
+    return X;
+  }
+}
+#endif

--- a/include/interaction_list.h
+++ b/include/interaction_list.h
@@ -168,43 +168,48 @@ namespace exafmm_t {
       }
     }
   }
-
+  
   void setColleagues(Node* node) {
-    Node* parent_node;
-    Node* tmp_node1;
-    Node* tmp_node2;
-    for(int i=0; i<27; i++) node->colleague[i] = NULL;
-    parent_node = node->parent;
-    if(parent_node==NULL) return;
-    int l=node->octant;         // l is octant
-    for(int i=0; i<27; i++) {
-      tmp_node1 = parent_node->colleague[i];  // loop over parent's colleagues
-      if(tmp_node1!=NULL && !tmp_node1->IsLeaf()) {
-        for(int j=0; j<8; j++) {
-          tmp_node2=tmp_node1->Child(j);    // loop over parent's colleages child
-          if(tmp_node2!=NULL) {
-            bool flag=true;
-            int a=1, b=1, new_indx=0;
-            for(int k=0; k<3; k++) {
-              int indx_diff=(((i/b)%3)-1)*2+((j/a)%2)-((l/a)%2);
-              if(-1>indx_diff || indx_diff>1) flag=false;
-              new_indx+=(indx_diff+1)*b;
-              a*=2;
-              b*=3;
+    Node *parent, *colleague, *child;
+    for (int i=0; i<27; ++i) node->colleague[i] = NULL;
+    if (node->depth==0) {     // root node
+      node->colleague[13] = node;
+    } else {                  // non-root node
+      parent = node->parent;
+      int l = node->octant;
+      for(int i=0; i<27; ++i) { // loop over parent's colleagues
+        colleague = parent->colleague[i]; 
+        if(colleague!=NULL && !colleague->IsLeaf()) {
+          for(int j=0; j<8; ++j) {  // loop over parent's colleages child
+            child = colleague->Child(j);
+            if(child!=NULL) {
+              bool flag=true;
+              int a=1, b=1, new_indx=0;
+              for(int k=0; k<3; ++k) {
+                int indx_diff=(((i/b)%3)-1)*2+((j/a)%2)-((l/a)%2);
+                if(-1>indx_diff || indx_diff>1) flag=false;
+                new_indx+=(indx_diff+1)*b;
+                a*=2;
+                b*=3;
+              }
+              if(flag)
+                node->colleague[new_indx] = child;
             }
-            if(flag)
-              node->colleague[new_indx] = tmp_node2;
           }
+        }
+      }
+    }
+    if (!node->IsLeaf()) {
+      for (int c=0; c<8; ++c) {
+        if (node->child[c] != NULL) {
+          setColleagues(node->child[c]);
         }
       }
     }
   }
 
   void setColleagues(Nodes& nodes) {
-    nodes[0].colleague[13] = &nodes[0];
-    for(int i=1; i<nodes.size(); i++) {
-      setColleagues(&nodes[i]);
-    }
+    setColleagues(&nodes[0]);
   }
 }
 #endif

--- a/include/traverse.h
+++ b/include/traverse.h
@@ -56,11 +56,13 @@ namespace exafmm_t {
     }
     real_t p_diff = 0, p_norm = 0, g_diff = 0, g_norm = 0;
     for(size_t i=0; i<targets.size(); i++) {
-      p_norm += targets2[i].pt_trg[0] * targets2[i].pt_trg[0];
-      p_diff += (targets2[i].pt_trg[0] - targets[i].pt_trg[0]) * (targets2[i].pt_trg[0] - targets[i].pt_trg[0]);
-      for(int d=1; d<4; d++) {
-        g_diff += (targets2[i].pt_trg[d] - targets[i].pt_trg[d]) * (targets2[i].pt_trg[d] - targets[i].pt_trg[d]);
-        g_norm += targets2[i].pt_trg[d] * targets2[i].pt_trg[d];
+      if (targets2[i].numBodies != 0) {  // if current leaf is not empty
+        p_norm += targets2[i].pt_trg[0] * targets2[i].pt_trg[0];
+        p_diff += (targets2[i].pt_trg[0] - targets[i].pt_trg[0]) * (targets2[i].pt_trg[0] - targets[i].pt_trg[0]);
+        for(int d=1; d<4; d++) {
+          g_diff += (targets2[i].pt_trg[d] - targets[i].pt_trg[d]) * (targets2[i].pt_trg[d] - targets[i].pt_trg[d]);
+          g_norm += targets2[i].pt_trg[d] * targets2[i].pt_trg[d];
+        }
       }
     }
     RealVec l2_error(2);

--- a/main.cpp
+++ b/main.cpp
@@ -19,7 +19,7 @@ int main(int argc, char **argv) {
   RealVec src_coord, src_value;
 
   Profile::Tic("Total", true);
-  Bodies bodies = cube(args.numBodies, 0);
+  Bodies bodies = plummer(args.numBodies, 0);
   std::vector<Node*> leafs, nonleafs;
   Nodes nodes = buildTree(bodies, leafs, nonleafs, args);
   MAXLEVEL = 0;

--- a/main.cpp
+++ b/main.cpp
@@ -27,6 +27,12 @@ int main(int argc, char **argv) {
     MAXLEVEL = std::max(MAXLEVEL, leafs[i]->depth);
   }
 
+  // balanced tree
+  std::unordered_map<uint64_t, size_t> key2id;
+  Keys keys = breadthFirstTraversal(&nodes[0], key2id);
+  Keys bkeys = balanceTree(keys, key2id, nodes);
+  Keys leafkeys = findLeafKeys(bkeys);
+
   // fill in pt_coord, pt_src, correct coord for compatibility
   // remove this later
   for(int i=0; i<nodes.size(); i++) {

--- a/main.cpp
+++ b/main.cpp
@@ -19,7 +19,7 @@ int main(int argc, char **argv) {
   RealVec src_coord, src_value;
 
   Profile::Tic("Total", true);
-  Bodies bodies = cube(args.numBodies, 0);
+  Bodies bodies = initBodies(args.numBodies, args.distribution, 0);
   std::vector<Node*> leafs, nonleafs;
   Nodes nodes = buildTree(bodies, leafs, nonleafs, args);
 

--- a/main.cpp
+++ b/main.cpp
@@ -19,19 +19,20 @@ int main(int argc, char **argv) {
   RealVec src_coord, src_value;
 
   Profile::Tic("Total", true);
-  Bodies bodies = plummer(args.numBodies, 0);
+  Bodies bodies = cube(args.numBodies, 0);
   std::vector<Node*> leafs, nonleafs;
   Nodes nodes = buildTree(bodies, leafs, nonleafs, args);
-  MAXLEVEL = 0;
-  for(size_t i=0; i<leafs.size(); i++) {
-    MAXLEVEL = std::max(MAXLEVEL, leafs[i]->depth);
-  }
 
   // balanced tree
   std::unordered_map<uint64_t, size_t> key2id;
   Keys keys = breadthFirstTraversal(&nodes[0], key2id);
   Keys bkeys = balanceTree(keys, key2id, nodes);
   Keys leafkeys = findLeafKeys(bkeys);
+  nodes.clear();
+  leafs.clear();
+  nonleafs.clear();
+  nodes = buildTree(bodies, leafs, nonleafs, args, leafkeys);  // rebuild 2:1 balanced tree
+  MAXLEVEL = keys.size() - 1;
 
   // fill in pt_coord, pt_src, correct coord for compatibility
   // remove this later
@@ -60,7 +61,7 @@ int main(int argc, char **argv) {
   Profile::Toc();
   RealVec error = verify(leafs);
   std::cout << std::setw(20) << std::left << "Leaf Nodes" << " : "<< leafs.size() << std::endl;
-  std::cout << std::setw(20) << std::left << "Tree Depth" << " : "<< leafs.back()->depth << std::endl;
+  std::cout << std::setw(20) << std::left << "Tree Depth" << " : "<< MAXLEVEL << std::endl;
   std::cout << std::setw(20) << std::left << "Potn Error" << " : " << std::scientific << error[0] << std::endl;
   std::cout << std::setw(20) << std::left << "Grad Error" << " : " << std::scientific << error[1] << std::endl;
   Profile::print();


### PR DESCRIPTION
The code now can build a 2:1 balanced tree by using Morton index to find the nodes that have to exist in order to satisfy the balance requirement. To work with current M2L kernel, each non-leaf node now has all 8 children no matter whether there are any bodies in that octant.

Use `-d p` in args to test with plummer distribution.