### PR TITLE
change xmin to x in Node class

### DIFF
--- a/include/exafmm_t.h
+++ b/include/exafmm_t.h
@@ -98,7 +98,7 @@ namespace exafmm_t {
     bool is_leaf;
     int ntrgs;
     int nsrcs;
-    vec3 x;    // the coordinates of the front-left-bottom corner
+    vec3 x;    // the coordinates of the center of the node
     real_t r;
     uint64_t key;
     int level;

--- a/include/exafmm_t.h
+++ b/include/exafmm_t.h
@@ -98,7 +98,7 @@ namespace exafmm_t {
     bool is_leaf;
     int ntrgs;
     int nsrcs;
-    vec3 xmin;    // the coordinates of the front-left-bottom corner
+    vec3 x;    // the coordinates of the front-left-bottom corner
     real_t r;
     uint64_t key;
     int level;
@@ -161,7 +161,7 @@ namespace exafmm_t {
   extern int P;   // order of multipole expansion
   extern int NSURF;     // number of surface coordinates
   extern int MAXLEVEL;  // max depth of tree
-  extern vec3 XMIN0;    // coordinates of root
+  extern vec3 X0;    // root's center
   extern real_t R0;     // radius of root
 #if HELMHOLTZ
   extern real_t WAVEK;     // wave number of Helmholtz kernel

--- a/include/hilbert.h
+++ b/include/hilbert.h
@@ -132,20 +132,22 @@ namespace exafmm_t {
 
   //! Get 3-D index from coordinates
   ivec3 get3DIndex(vec3 X, int level) {
+    vec3 Xmin = X0 - R0;
     real_t dx = 2 * R0 / (1 << level);
     ivec3 iX;
     for (int d=0; d<3; d++) {
-      iX[d] = floor((X[d] - XMIN0[d]) / dx);
+      iX[d] = floor((X[d] - Xmin[d]) / dx);
     }
     return iX;
   }
 
   //! Get coordinates from 3-D index
   vec3 getCoordinates(ivec3 iX, int level) {
+    vec3 Xmin = X0 - R0;
     real_t dx = 2 * R0 / (1 << level);
     vec3 X;
     for (int d=0; d<3; d++) {
-      X[d] = (iX[d] + 0.5) * dx + XMIN0[d];
+      X[d] = (iX[d] + 0.5) * dx + Xmin[d];
     }
     return X;
   }

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -7,7 +7,8 @@ namespace exafmm_t {
   // alpha is the ratio r_surface/r_node
   // 2.95 for upward check surface / downward equivalent surface
   // 1.05 for upward equivalent surface / downward check surface
-  RealVec surface(int p, real_t* c, real_t alpha, int level, bool is_mapping){
+  // c is now the center of node
+  RealVec surface(int p, real_t* c, real_t alpha, int level, bool is_mapping) {
     size_t n = 6*(p-1)*(p-1) + 2;
     RealVec coord(n*3);
     coord[0] = -1.0;
@@ -44,19 +45,17 @@ namespace exafmm_t {
     real_t r = is_mapping ? 0.5 : R0;
     r *= powf(0.5, level);
     real_t b = alpha * r;
-    real_t br = b - r;
     for(size_t i=0; i<n; i++){
-      coord[i*3+0] = (coord[i*3+0]+1.0)*b + c[0]- br;
-      coord[i*3+1] = (coord[i*3+1]+1.0)*b + c[1]- br;
-      coord[i*3+2] = (coord[i*3+2]+1.0)*b + c[2]- br;
+      coord[i*3+0] = (coord[i*3+0]+1.0)*b + c[0] - b;
+      coord[i*3+1] = (coord[i*3+1]+1.0)*b + c[1] - b;
+      coord[i*3+2] = (coord[i*3+2]+1.0)*b + c[2] - b;
     }
     return coord;
   }
 
-  RealVec convolution_grid(real_t* c, int level){
-    real_t r = R0 * powf(0.5, level-1);
-    real_t a = r * 1.05;
-    real_t coord[3] = {c[0], c[1], c[2]};
+  RealVec convolution_grid(real_t* c, int level) {
+    real_t d = 2 * R0 * powf(0.5, level);  // diameter
+    real_t a = d * 1.05;  // diameter of upward equivalent/downward check box
     int n1 = P * 2;
     int n2 = n1 * n1;
     int n3 = n1 * n1 * n1;
@@ -64,9 +63,9 @@ namespace exafmm_t {
     for(int i=0; i<n1; i++) {
       for(int j=0; j<n1; j++) {
         for(int k=0; k<n1; k++) {
-          grid[(i+n1*j+n2*k)*3+0] = (i-P)*a/(P-1) + coord[0];
-          grid[(i+n1*j+n2*k)*3+1] = (j-P)*a/(P-1) + coord[1];
-          grid[(i+n1*j+n2*k)*3+2] = (k-P)*a/(P-1) + coord[2];
+          grid[(i+n1*j+n2*k)*3+0] = (i-P)*a/(P-1) + c[0];
+          grid[(i+n1*j+n2*k)*3+1] = (j-P)*a/(P-1) + c[1];
+          grid[(i+n1*j+n2*k)*3+2] = (k-P)*a/(P-1) + c[2];
         }
       }
     }

--- a/src/helmholtz.cpp
+++ b/src/helmholtz.cpp
@@ -254,7 +254,7 @@ namespace exafmm_t {
   }
 
   void P2M(NodePtrs& leafs) {
-    real_t c[3] = {0.0};
+    real_t c[3] = {0, 0, 0};
     std::vector<RealVec> up_check_surf;
     up_check_surf.resize(MAXLEVEL+1);
     for(int level=0; level<=MAXLEVEL; level++) {
@@ -267,9 +267,9 @@ namespace exafmm_t {
       int level = leaf->level;
       RealVec checkCoord(NSURF*3);
       for(int k=0; k<NSURF; k++) {
-        checkCoord[3*k+0] = up_check_surf[level][3*k+0] + leaf->xmin[0];
-        checkCoord[3*k+1] = up_check_surf[level][3*k+1] + leaf->xmin[1];
-        checkCoord[3*k+2] = up_check_surf[level][3*k+2] + leaf->xmin[2];
+        checkCoord[3*k+0] = up_check_surf[level][3*k+0] + leaf->xmin[0] + leaf->r;
+        checkCoord[3*k+1] = up_check_surf[level][3*k+1] + leaf->xmin[1] + leaf->r;
+        checkCoord[3*k+2] = up_check_surf[level][3*k+2] + leaf->xmin[2] + leaf->r;
       }
       potential_P2P(leaf->src_coord, leaf->src_value, checkCoord, leaf->up_equiv);
       ComplexVec buffer(NSURF);
@@ -323,7 +323,7 @@ namespace exafmm_t {
   } 
 
   void L2P(NodePtrs& leafs) {
-    real_t c[3] = {0.0};
+    real_t c[3] = {0, 0, 0};
     std::vector<RealVec> dn_equiv_surf;
     dn_equiv_surf.resize(MAXLEVEL+1);
     for(int level = 0; level <= MAXLEVEL; level++) {
@@ -344,9 +344,9 @@ namespace exafmm_t {
       // equivalent surface charge -> target potential
       RealVec equivCoord(NSURF*3);
       for(int k=0; k<NSURF; k++) {
-        equivCoord[3*k+0] = dn_equiv_surf[level][3*k+0] + leaf->xmin[0];
-        equivCoord[3*k+1] = dn_equiv_surf[level][3*k+1] + leaf->xmin[1];
-        equivCoord[3*k+2] = dn_equiv_surf[level][3*k+2] + leaf->xmin[2];
+        equivCoord[3*k+0] = dn_equiv_surf[level][3*k+0] + leaf->xmin[0] + leaf->r;
+        equivCoord[3*k+1] = dn_equiv_surf[level][3*k+1] + leaf->xmin[1] + leaf->r;
+        equivCoord[3*k+2] = dn_equiv_surf[level][3*k+2] + leaf->xmin[2] + leaf->r;
       }
       gradient_P2P(equivCoord, leaf->dn_equiv, leaf->trg_coord, leaf->trg_value);
     }
@@ -371,9 +371,9 @@ namespace exafmm_t {
         int level = target->level;
         // target node's check coord = relative check coord + node's origin
         for(int k=0; k<NSURF; k++) {
-          trg_check_coord[3*k+0] = dn_check_surf[level][3*k+0] + target->xmin[0];
-          trg_check_coord[3*k+1] = dn_check_surf[level][3*k+1] + target->xmin[1];
-          trg_check_coord[3*k+2] = dn_check_surf[level][3*k+2] + target->xmin[2];
+          trg_check_coord[3*k+0] = dn_check_surf[level][3*k+0] + target->xmin[0] + target->r;
+          trg_check_coord[3*k+1] = dn_check_surf[level][3*k+1] + target->xmin[1] + target->r;
+          trg_check_coord[3*k+2] = dn_check_surf[level][3*k+2] + target->xmin[2] + target->r;
         }
         potential_P2P(source->src_coord, source->src_value, trg_check_coord, target->dn_equiv);
       }
@@ -399,9 +399,9 @@ namespace exafmm_t {
         int level = source->level;
         // source node's equiv coord = relative equiv coord + node's origin
         for(int k=0; k<NSURF; k++) {
-          sourceEquivCoord[3*k+0] = up_equiv_surf[level][3*k+0] + source->xmin[0];
-          sourceEquivCoord[3*k+1] = up_equiv_surf[level][3*k+1] + source->xmin[1];
-          sourceEquivCoord[3*k+2] = up_equiv_surf[level][3*k+2] + source->xmin[2];
+          sourceEquivCoord[3*k+0] = up_equiv_surf[level][3*k+0] + source->xmin[0] + source->r;
+          sourceEquivCoord[3*k+1] = up_equiv_surf[level][3*k+1] + source->xmin[1] + source->r;
+          sourceEquivCoord[3*k+2] = up_equiv_surf[level][3*k+2] + source->xmin[2] + source->r;
         }
         gradient_P2P(sourceEquivCoord, source->up_equiv, target->trg_coord, target->trg_value);
       }
@@ -544,7 +544,7 @@ namespace exafmm_t {
     int n1 = P * 2;
     int n3 = n1 * n1 * n1;
     std::vector<size_t> map(NSURF);
-    real_t c[3]= {0, 0, 0};
+    real_t c[3]= {0.5, 0.5, 0.5};
     for(int d=0; d<3; d++) c[d] += 0.5*(P-2);
     RealVec surf = surface(P, c, (real_t)(P-1), 0, true);
     for(size_t i=0; i<map.size(); i++) {
@@ -590,7 +590,7 @@ namespace exafmm_t {
     int n1 = P * 2;
     int n3 = n1 * n1 * n1;
     std::vector<size_t> map(NSURF);
-    real_t c[3]= {0, 0, 0};
+    real_t c[3]= {0.5, 0.5, 0.5};
     for(int d=0; d<3; d++) c[d] += 0.5*(P-2);
     RealVec surf = surface(P, c, (real_t)(P-1), 0, true);
     for(size_t i=0; i<map.size(); i++) {

--- a/src/helmholtz.cpp
+++ b/src/helmholtz.cpp
@@ -267,9 +267,9 @@ namespace exafmm_t {
       int level = leaf->level;
       RealVec checkCoord(NSURF*3);
       for(int k=0; k<NSURF; k++) {
-        checkCoord[3*k+0] = up_check_surf[level][3*k+0] + leaf->xmin[0] + leaf->r;
-        checkCoord[3*k+1] = up_check_surf[level][3*k+1] + leaf->xmin[1] + leaf->r;
-        checkCoord[3*k+2] = up_check_surf[level][3*k+2] + leaf->xmin[2] + leaf->r;
+        checkCoord[3*k+0] = up_check_surf[level][3*k+0] + leaf->x[0];
+        checkCoord[3*k+1] = up_check_surf[level][3*k+1] + leaf->x[1];
+        checkCoord[3*k+2] = up_check_surf[level][3*k+2] + leaf->x[2];
       }
       potential_P2P(leaf->src_coord, leaf->src_value, checkCoord, leaf->up_equiv);
       ComplexVec buffer(NSURF);
@@ -344,9 +344,9 @@ namespace exafmm_t {
       // equivalent surface charge -> target potential
       RealVec equivCoord(NSURF*3);
       for(int k=0; k<NSURF; k++) {
-        equivCoord[3*k+0] = dn_equiv_surf[level][3*k+0] + leaf->xmin[0] + leaf->r;
-        equivCoord[3*k+1] = dn_equiv_surf[level][3*k+1] + leaf->xmin[1] + leaf->r;
-        equivCoord[3*k+2] = dn_equiv_surf[level][3*k+2] + leaf->xmin[2] + leaf->r;
+        equivCoord[3*k+0] = dn_equiv_surf[level][3*k+0] + leaf->x[0];
+        equivCoord[3*k+1] = dn_equiv_surf[level][3*k+1] + leaf->x[1];
+        equivCoord[3*k+2] = dn_equiv_surf[level][3*k+2] + leaf->x[2];
       }
       gradient_P2P(equivCoord, leaf->dn_equiv, leaf->trg_coord, leaf->trg_value);
     }
@@ -371,9 +371,9 @@ namespace exafmm_t {
         int level = target->level;
         // target node's check coord = relative check coord + node's origin
         for(int k=0; k<NSURF; k++) {
-          trg_check_coord[3*k+0] = dn_check_surf[level][3*k+0] + target->xmin[0] + target->r;
-          trg_check_coord[3*k+1] = dn_check_surf[level][3*k+1] + target->xmin[1] + target->r;
-          trg_check_coord[3*k+2] = dn_check_surf[level][3*k+2] + target->xmin[2] + target->r;
+          trg_check_coord[3*k+0] = dn_check_surf[level][3*k+0] + target->x[0];
+          trg_check_coord[3*k+1] = dn_check_surf[level][3*k+1] + target->x[1];
+          trg_check_coord[3*k+2] = dn_check_surf[level][3*k+2] + target->x[2];
         }
         potential_P2P(source->src_coord, source->src_value, trg_check_coord, target->dn_equiv);
       }
@@ -399,9 +399,9 @@ namespace exafmm_t {
         int level = source->level;
         // source node's equiv coord = relative equiv coord + node's origin
         for(int k=0; k<NSURF; k++) {
-          sourceEquivCoord[3*k+0] = up_equiv_surf[level][3*k+0] + source->xmin[0] + source->r;
-          sourceEquivCoord[3*k+1] = up_equiv_surf[level][3*k+1] + source->xmin[1] + source->r;
-          sourceEquivCoord[3*k+2] = up_equiv_surf[level][3*k+2] + source->xmin[2] + source->r;
+          sourceEquivCoord[3*k+0] = up_equiv_surf[level][3*k+0] + source->x[0];
+          sourceEquivCoord[3*k+1] = up_equiv_surf[level][3*k+1] + source->x[1];
+          sourceEquivCoord[3*k+2] = up_equiv_surf[level][3*k+2] + source->x[2];
         }
         gradient_P2P(sourceEquivCoord, source->up_equiv, target->trg_coord, target->trg_value);
       }

--- a/src/laplace.cpp
+++ b/src/laplace.cpp
@@ -167,9 +167,9 @@ namespace exafmm_t {
       // calculate upward check potential induced by sources' charges
       RealVec checkCoord(NSURF*3);
       for(int k=0; k<NSURF; k++) {
-        checkCoord[3*k+0] = up_check_surf[level][3*k+0] + leaf->xmin[0] + leaf->r;
-        checkCoord[3*k+1] = up_check_surf[level][3*k+1] + leaf->xmin[1] + leaf->r;
-        checkCoord[3*k+2] = up_check_surf[level][3*k+2] + leaf->xmin[2] + leaf->r;
+        checkCoord[3*k+0] = up_check_surf[level][3*k+0] + leaf->x[0];
+        checkCoord[3*k+1] = up_check_surf[level][3*k+1] + leaf->x[1];
+        checkCoord[3*k+2] = up_check_surf[level][3*k+2] + leaf->x[2];
       }
       potential_P2P(leaf->src_coord, leaf->src_value, checkCoord, leaf->up_equiv);
       // convert upward check potential to upward equivalent charge
@@ -248,9 +248,9 @@ namespace exafmm_t {
       // calculate targets' potential & gradient induced by downward equivalent charge
       RealVec equivCoord(NSURF*3);
       for(int k=0; k<NSURF; k++) {
-        equivCoord[3*k+0] = dn_equiv_surf[level][3*k+0] + leaf->xmin[0] + leaf->r;
-        equivCoord[3*k+1] = dn_equiv_surf[level][3*k+1] + leaf->xmin[1] + leaf->r;
-        equivCoord[3*k+2] = dn_equiv_surf[level][3*k+2] + leaf->xmin[2] + leaf->r;
+        equivCoord[3*k+0] = dn_equiv_surf[level][3*k+0] + leaf->x[0];
+        equivCoord[3*k+1] = dn_equiv_surf[level][3*k+1] + leaf->x[1];
+        equivCoord[3*k+2] = dn_equiv_surf[level][3*k+2] + leaf->x[2];
       }
       gradient_P2P(equivCoord, leaf->dn_equiv, leaf->trg_coord, leaf->trg_value);
     }
@@ -275,9 +275,9 @@ namespace exafmm_t {
         int level = target->level;
         // target node's check coord = relative check coord + node's origin
         for(int k=0; k<NSURF; k++) {
-          trg_check_coord[3*k+0] = dn_check_surf[level][3*k+0] + target->xmin[0] + target->r;
-          trg_check_coord[3*k+1] = dn_check_surf[level][3*k+1] + target->xmin[1] + target->r;
-          trg_check_coord[3*k+2] = dn_check_surf[level][3*k+2] + target->xmin[2] + target->r;
+          trg_check_coord[3*k+0] = dn_check_surf[level][3*k+0] + target->x[0];
+          trg_check_coord[3*k+1] = dn_check_surf[level][3*k+1] + target->x[1];
+          trg_check_coord[3*k+2] = dn_check_surf[level][3*k+2] + target->x[2];
         }
         potential_P2P(source->src_coord, source->src_value, trg_check_coord, target->dn_equiv);
       }
@@ -303,9 +303,9 @@ namespace exafmm_t {
         int level = source->level;
         // source node's equiv coord = relative equiv coord + node's origin
         for(int k=0; k<NSURF; k++) {
-          sourceEquivCoord[3*k+0] = up_equiv_surf[level][3*k+0] + source->xmin[0] + source->r;
-          sourceEquivCoord[3*k+1] = up_equiv_surf[level][3*k+1] + source->xmin[1] + source->r;
-          sourceEquivCoord[3*k+2] = up_equiv_surf[level][3*k+2] + source->xmin[2] + source->r;
+          sourceEquivCoord[3*k+0] = up_equiv_surf[level][3*k+0] + source->x[0];
+          sourceEquivCoord[3*k+1] = up_equiv_surf[level][3*k+1] + source->x[1];
+          sourceEquivCoord[3*k+2] = up_equiv_surf[level][3*k+2] + source->x[2];
         }
         gradient_P2P(sourceEquivCoord, source->up_equiv, target->trg_coord, target->trg_value);
       }

--- a/src/laplace.cpp
+++ b/src/laplace.cpp
@@ -152,7 +152,7 @@ namespace exafmm_t {
   }
 
   void P2M(NodePtrs& leafs) {
-    real_t c[3] = {0.0};
+    real_t c[3] = {0,0,0};
     std::vector<RealVec> up_check_surf;
     up_check_surf.resize(MAXLEVEL+1);
     for(int level = 0; level <= MAXLEVEL; level++) {
@@ -167,9 +167,9 @@ namespace exafmm_t {
       // calculate upward check potential induced by sources' charges
       RealVec checkCoord(NSURF*3);
       for(int k=0; k<NSURF; k++) {
-        checkCoord[3*k+0] = up_check_surf[level][3*k+0] + leaf->xmin[0];
-        checkCoord[3*k+1] = up_check_surf[level][3*k+1] + leaf->xmin[1];
-        checkCoord[3*k+2] = up_check_surf[level][3*k+2] + leaf->xmin[2];
+        checkCoord[3*k+0] = up_check_surf[level][3*k+0] + leaf->xmin[0] + leaf->r;
+        checkCoord[3*k+1] = up_check_surf[level][3*k+1] + leaf->xmin[1] + leaf->r;
+        checkCoord[3*k+2] = up_check_surf[level][3*k+2] + leaf->xmin[2] + leaf->r;
       }
       potential_P2P(leaf->src_coord, leaf->src_value, checkCoord, leaf->up_equiv);
       // convert upward check potential to upward equivalent charge
@@ -248,9 +248,9 @@ namespace exafmm_t {
       // calculate targets' potential & gradient induced by downward equivalent charge
       RealVec equivCoord(NSURF*3);
       for(int k=0; k<NSURF; k++) {
-        equivCoord[3*k+0] = dn_equiv_surf[level][3*k+0] + leaf->xmin[0];
-        equivCoord[3*k+1] = dn_equiv_surf[level][3*k+1] + leaf->xmin[1];
-        equivCoord[3*k+2] = dn_equiv_surf[level][3*k+2] + leaf->xmin[2];
+        equivCoord[3*k+0] = dn_equiv_surf[level][3*k+0] + leaf->xmin[0] + leaf->r;
+        equivCoord[3*k+1] = dn_equiv_surf[level][3*k+1] + leaf->xmin[1] + leaf->r;
+        equivCoord[3*k+2] = dn_equiv_surf[level][3*k+2] + leaf->xmin[2] + leaf->r;
       }
       gradient_P2P(equivCoord, leaf->dn_equiv, leaf->trg_coord, leaf->trg_value);
     }
@@ -275,9 +275,9 @@ namespace exafmm_t {
         int level = target->level;
         // target node's check coord = relative check coord + node's origin
         for(int k=0; k<NSURF; k++) {
-          trg_check_coord[3*k+0] = dn_check_surf[level][3*k+0] + target->xmin[0];
-          trg_check_coord[3*k+1] = dn_check_surf[level][3*k+1] + target->xmin[1];
-          trg_check_coord[3*k+2] = dn_check_surf[level][3*k+2] + target->xmin[2];
+          trg_check_coord[3*k+0] = dn_check_surf[level][3*k+0] + target->xmin[0] + target->r;
+          trg_check_coord[3*k+1] = dn_check_surf[level][3*k+1] + target->xmin[1] + target->r;
+          trg_check_coord[3*k+2] = dn_check_surf[level][3*k+2] + target->xmin[2] + target->r;
         }
         potential_P2P(source->src_coord, source->src_value, trg_check_coord, target->dn_equiv);
       }
@@ -303,9 +303,9 @@ namespace exafmm_t {
         int level = source->level;
         // source node's equiv coord = relative equiv coord + node's origin
         for(int k=0; k<NSURF; k++) {
-          sourceEquivCoord[3*k+0] = up_equiv_surf[level][3*k+0] + source->xmin[0];
-          sourceEquivCoord[3*k+1] = up_equiv_surf[level][3*k+1] + source->xmin[1];
-          sourceEquivCoord[3*k+2] = up_equiv_surf[level][3*k+2] + source->xmin[2];
+          sourceEquivCoord[3*k+0] = up_equiv_surf[level][3*k+0] + source->xmin[0] + source->r;
+          sourceEquivCoord[3*k+1] = up_equiv_surf[level][3*k+1] + source->xmin[1] + source->r;
+          sourceEquivCoord[3*k+2] = up_equiv_surf[level][3*k+2] + source->xmin[2] + source->r;
         }
         gradient_P2P(sourceEquivCoord, source->up_equiv, target->trg_coord, target->trg_value);
       }
@@ -444,7 +444,7 @@ namespace exafmm_t {
     int n3 = n1 * n1 * n1;
     int n3_ = n1 * n1 * (n1 / 2 + 1);
     std::vector<size_t> map(NSURF);
-    real_t c[3]= {0, 0, 0};
+    real_t c[3]= {0.5, 0.5, 0.5};
     for(int d=0; d<3; d++) c[d] += 0.5*(P-2);
     RealVec surf = surface(P, c, (real_t)(P-1), 0, true);
     for(size_t i=0; i<map.size(); i++) {
@@ -492,7 +492,7 @@ namespace exafmm_t {
     int n3 = n1 * n1 * n1;
     int n3_ = n1 * n1 * (n1 / 2 + 1);
     std::vector<size_t> map(NSURF);
-    real_t c[3]= {0, 0, 0};
+    real_t c[3]= {0.5, 0.5, 0.5};
     for(int d=0; d<3; d++) c[d] += 0.5*(P-2);
     RealVec surf = surface(P, c, (real_t)(P-1), 0, true);
     for(size_t i=0; i<map.size(); i++) {

--- a/src/precompute_helmholtz.cpp
+++ b/src/precompute_helmholtz.cpp
@@ -89,8 +89,8 @@ namespace exafmm_t {
     real_t c[3] = {0, 0, 0};
     for(int level = 0; level <= MAXLEVEL; level++) {
       // caculate matrix_UC2E_U and matrix_UC2E_V
-      RealVec up_check_surf = surface(P,c,2.95,level);
-      RealVec up_equiv_surf = surface(P,c,1.05,level);
+      RealVec up_check_surf = surface(P, c, 2.95, level);
+      RealVec up_equiv_surf = surface(P, c, 1.05, level);
       ComplexVec matrix_c2e(NSURF*NSURF);
       kernel_matrix(&up_check_surf[0], NSURF, &up_equiv_surf[0], NSURF, &matrix_c2e[0]);
       RealVec S(NSURF*NSURF);
@@ -123,15 +123,16 @@ namespace exafmm_t {
   void precompute_M2M() {
     real_t parent_coord[3] = {0, 0, 0};
     for(int level = 0; level <= MAXLEVEL; level++) {
-      RealVec parent_up_check_surf = surface(P,parent_coord,2.95,level);
+      RealVec parent_up_check_surf = surface(P, parent_coord, 2.95, level);
       real_t s = R0 * powf(0.5, level+1);
-
       int numRelCoord = REL_COORD[M2M_Type].size();
 #pragma omp parallel for
       for(int i=0; i<numRelCoord; i++) {
         ivec3& coord = REL_COORD[M2M_Type][i];
-        real_t child_coord[3] = {(coord[0]+1)*s, (coord[1]+1)*s, (coord[2]+1)*s};
-        RealVec child_up_equiv_surf = surface(P,child_coord,1.05,level+1);
+        real_t child_coord[3] = {parent_coord[0] + coord[0]*s,
+                                 parent_coord[1] + coord[1]*s,
+                                 parent_coord[2] + coord[2]*s};
+        RealVec child_up_equiv_surf = surface(P, child_coord, 1.05, level+1);
         ComplexVec matrix_pc2ce(NSURF*NSURF);
         kernel_matrix(&parent_up_check_surf[0], NSURF, &child_up_equiv_surf[0], NSURF, &matrix_pc2ce[0]);
         // M2M: child's upward_equiv to parent's check

--- a/src/precompute_laplace.cpp
+++ b/src/precompute_laplace.cpp
@@ -69,8 +69,8 @@ namespace exafmm_t {
     int level = 0;
     real_t c[3] = {0, 0, 0};
     // caculate upwardcheck to equiv U and V
-    RealVec up_check_surf = surface(P,c,2.95,level);
-    RealVec up_equiv_surf = surface(P,c,1.05,level);
+    RealVec up_check_surf = surface(P, c, 2.95, level);
+    RealVec up_equiv_surf = surface(P, c, 1.05, level);
     RealVec matrix_c2e(NSURF*NSURF);
     kernel_matrix(&up_check_surf[0], NSURF, &up_equiv_surf[0], NSURF, &matrix_c2e[0]);
     RealVec U(NSURF*NSURF), S(NSURF*NSURF), VT(NSURF*NSURF);
@@ -96,13 +96,15 @@ namespace exafmm_t {
     int numRelCoord = REL_COORD[M2M_Type].size();
     int level = 0;
     real_t parent_coord[3] = {0, 0, 0};
-    RealVec parent_up_check_surf = surface(P,parent_coord,2.95,level);
+    RealVec parent_up_check_surf = surface(P, parent_coord, 2.95, level);
     real_t s = R0 * powf(0.5, level+1);
 #pragma omp parallel for
     for(int i=0; i<numRelCoord; i++) {
       ivec3& coord = REL_COORD[M2M_Type][i];
-      real_t child_coord[3] = {(coord[0]+1)*s, (coord[1]+1)*s, (coord[2]+1)*s};
-      RealVec child_up_equiv_surf = surface(P,child_coord,1.05,level+1);
+      real_t child_coord[3] = {parent_coord[0] + coord[0]*s,
+                               parent_coord[1] + coord[1]*s,
+                               parent_coord[2] + coord[2]*s};
+      RealVec child_up_equiv_surf = surface(P, child_coord, 1.05, level+1);
       RealVec matrix_pc2ce(NSURF*NSURF);
       kernel_matrix(&parent_up_check_surf[0], NSURF, &child_up_equiv_surf[0], NSURF, &matrix_pc2ce[0]);
       // M2M

--- a/tests/fmm.cpp
+++ b/tests/fmm.cpp
@@ -17,7 +17,7 @@ namespace exafmm_t {
   int P;
   int NSURF;
   int MAXLEVEL;
-  vec3 XMIN0;
+  vec3 X0;
   real_t R0;
 #if HELMHOLTZ
   real_t WAVEK;
@@ -46,14 +46,14 @@ int main(int argc, char **argv) {
   Bodies targets = init_bodies(args.numBodies, args.distribution, 5, false);
 
   start("Build Tree");
-  get_bounds(sources, targets, XMIN0, R0);
+  get_bounds(sources, targets, X0, R0);
   NodePtrs leafs, nonleafs;
 #if NON_ADAPTIVE
   MAXLEVEL = args.maxlevel;   // explicitly define the max level when constructing a full tree
-  Nodes nodes = build_tree(sources, targets, XMIN0, R0, leafs, nonleafs);
+  Nodes nodes = build_tree(sources, targets, X0, R0, leafs, nonleafs);
 #else
-  Nodes nodes = build_tree(sources, targets, XMIN0, R0, leafs, nonleafs, args);
-  balance_tree(nodes, sources, targets, XMIN0, R0, leafs, nonleafs, args);
+  Nodes nodes = build_tree(sources, targets, X0, R0, leafs, nonleafs, args);
+  balance_tree(nodes, sources, targets, X0, R0, leafs, nonleafs, args);
 #endif
   stop("Build Tree");
 
@@ -77,9 +77,9 @@ int main(int argc, char **argv) {
   print("Gradient Error", error[1]);
   
   print_divider("Tree");
-  print("Root Center x", XMIN0[0] + R0);
-  print("Root Center y", XMIN0[1] + R0);
-  print("Root Center z", XMIN0[2] + R0);
+  print("Root Center x", X0[0]);
+  print("Root Center y", X0[1]);
+  print("Root Center z", X0[2]);
   print("Root Radius R", R0);
   print("Tree Depth", MAXLEVEL);
   print("Leaf Nodes", leafs.size());

--- a/tests/kernel.cpp
+++ b/tests/kernel.cpp
@@ -13,7 +13,7 @@ namespace exafmm_t {
   int P;
   int NSURF;
   int MAXLEVEL;
-  vec3 XMIN0;
+  vec3 X0;
   real_t R0;
 #if HELMHOLTZ
   real_t WAVEK;
@@ -30,10 +30,10 @@ void set_children(Node* parent, Node* first_child) {
     child->octant = octant;
     child->parent = parent;
     child->level = parent->level + 1;
+    child->x = parent->x;
     child->r = parent->r / 2;
-    child->xmin = parent->xmin;
     for(int d=0; d<3; d++) {
-      child->xmin[d] += parent->r * ((octant & 1 << d) >> d);
+      child->x[d] += child->r * (((octant & 1 << d) >> d) * 2 - 1);
     }
     parent->children.push_back(child);
   }
@@ -44,7 +44,7 @@ int main() {
   P = 8;
   NSURF = 6*(P-1)*(P-1) + 2;
   MAXLEVEL = 3;
-  XMIN0 = 0.;
+  X0 = 4.;
   R0 = 4.;
 #if HELMHOLTZ
   WAVEK = 10;
@@ -72,7 +72,7 @@ int main() {
   // set root node
   Node* root = &nodes[0];
   root->parent = nullptr;
-  root->xmin = XMIN0;
+  root->x = X0;
   root->r = R0;
   root->level = 0;
 

--- a/tests/list.cpp
+++ b/tests/list.cpp
@@ -11,7 +11,7 @@ namespace exafmm_t {
   int P;
   int NSURF;
   int MAXLEVEL;
-  vec3 XMIN0;
+  vec3 X0;
   real_t R0;
 #if HELMHOLTZ
   real_t WAVEK;
@@ -28,10 +28,10 @@ int main(int argc, char** argv) {
   Bodies sources = init_bodies(args.numBodies, args.distribution, 0, true);
   Bodies targets = init_bodies(args.numBodies, args.distribution, 5, false);
   
-  get_bounds(sources, targets, XMIN0, R0);
+  get_bounds(sources, targets, X0, R0);
   NodePtrs leafs, nonleafs;
-  Nodes nodes = build_tree(sources, targets, XMIN0, R0, leafs, nonleafs, args);
-  balance_tree(nodes, sources, targets, XMIN0, R0, leafs, nonleafs, args);
+  Nodes nodes = build_tree(sources, targets, X0, R0, leafs, nonleafs, args);
+  balance_tree(nodes, sources, targets, X0, R0, leafs, nonleafs, args);
   init_rel_coord();
   set_colleagues(nodes);
   build_list(nodes);

--- a/tests/p2p.cpp
+++ b/tests/p2p.cpp
@@ -12,7 +12,7 @@ namespace exafmm_t {
   int P;
   int NSURF;
   int MAXLEVEL;
-  vec3 XMIN0;
+  vec3 X0;
   real_t R0;
 #if HELMHOLTZ
   real_t WAVEK;

--- a/tests/tree.cpp
+++ b/tests/tree.cpp
@@ -9,7 +9,7 @@ namespace exafmm_t {
   int P;
   int NSURF;
   int MAXLEVEL;
-  vec3 XMIN0;
+  vec3 X0;
   real_t R0;
 #if HELMHOLTZ
   real_t WAVEK;
@@ -24,10 +24,10 @@ int main(int argc, char** argv) {
   Bodies sources = init_bodies(args.numBodies, args.distribution, 0, true);
   Bodies targets = init_bodies(args.numBodies, args.distribution, 5, false);
   
-  get_bounds(sources, targets, XMIN0, R0);
+  get_bounds(sources, targets, X0, R0);
   NodePtrs leafs, nonleafs;
-  Nodes nodes = build_tree(sources, targets, XMIN0, R0, leafs, nonleafs, args);
-  balance_tree(nodes, sources, targets, XMIN0, R0, leafs, nonleafs, args);
+  Nodes nodes = build_tree(sources, targets, X0, R0, leafs, nonleafs, args);
+  balance_tree(nodes, sources, targets, X0, R0, leafs, nonleafs, args);
 
   Node* root = nodes.data();
   P2M(leafs);

--- a/wrappers/bempp/bempp_wrapper.cpp
+++ b/wrappers/bempp/bempp_wrapper.cpp
@@ -16,7 +16,7 @@ namespace exafmm_t {
   int P;
   int NSURF;
   int MAXLEVEL;
-  vec3 XMIN0;
+  vec3 X0;
   real_t R0;
 #if HELMHOLTZ
   real_t WAVEK;
@@ -64,9 +64,9 @@ namespace exafmm_t {
     Bodies targets = array_to_bodies(trg_count, trg_coord);
 
     start("Build Tree");
-    get_bounds(sources, targets, XMIN0, R0);
+    get_bounds(sources, targets, X0, R0);
     NodePtrs nonleafs;
-    NODES = build_tree(sources, targets, XMIN0, R0, LEAFS, nonleafs);
+    NODES = build_tree(sources, targets, X0, R0, LEAFS, nonleafs);
     stop("Build Tree");
 
     init_rel_coord();
@@ -141,9 +141,9 @@ namespace exafmm_t {
 
   extern "C" void print_tree() {
     print_divider("Tree");
-    print("Root Center x", XMIN0[0] + R0);
-    print("Root Center y", XMIN0[1] + R0);
-    print("Root Center z", XMIN0[2] + R0);
+    print("Root Center x", X0[0]);
+    print("Root Center y", X0[1]);
+    print("Root Center z", X0[2]);
     print("Root Radius R", R0);
     print("Tree Depth", MAXLEVEL);
     print("Leaf Nodes", LEAFS.size());


### PR DESCRIPTION
We now store the coordinates of the center of a node in Node class, instead of using xmin, the coordinates of the lower left corner of a node. 

Global variable: XMIN0 -> X0
The function `surface` now takes in center coords.