### PR TITLE
Keep only one level of M2L matrix in buffer for Helmholtz kernel

### DIFF
--- a/include/exafmm_t.h
+++ b/include/exafmm_t.h
@@ -151,7 +151,6 @@ namespace exafmm_t {
   extern std::vector<ComplexVec> matrix_UC2E_U, matrix_UC2E_V;
   extern std::vector<ComplexVec> matrix_DC2E_U, matrix_DC2E_V;
   extern std::vector<std::vector<ComplexVec>> matrix_M2M, matrix_L2L;
-  extern std::vector<std::vector<AlignedVec>> matrix_M2L;
 #else
   extern RealVec matrix_UC2E_U, matrix_UC2E_V;
   extern RealVec matrix_DC2E_U, matrix_DC2E_V;

--- a/include/geometry.h
+++ b/include/geometry.h
@@ -12,5 +12,7 @@ namespace exafmm_t {
   void init_rel_coord(int max_r, int min_r, int step, Mat_Type t);
 
   void init_rel_coord();
+
+  std::vector<std::vector<int>> map_matrix_index();
 } // end namespace
 #endif

--- a/include/helmholtz.h
+++ b/include/helmholtz.h
@@ -40,7 +40,7 @@ namespace exafmm_t {
   void M2L_setup(std::vector<Node*>& nonleafs);
 
   void hadamard_product(std::vector<size_t>& interac_dsp, std::vector<size_t>& interac_vec,
-                       AlignedVec& fft_in, AlignedVec& fft_out, int level);
+                       AlignedVec& fft_in, AlignedVec& fft_out, std::vector<AlignedVec>& matrix_M2L);
 
   void fft_up_equiv(std::vector<size_t>& fft_vec, ComplexVec& all_up_equiv, AlignedVec& fft_in);
 

--- a/include/precompute_helmholtz.h
+++ b/include/precompute_helmholtz.h
@@ -26,19 +26,19 @@ namespace exafmm_t {
 
   ComplexVec conjugate_transpose(ComplexVec& vec, int m, int n);
 
+  std::vector<std::vector<int>> map_matrix_index();
+
   void initialize_matrix();
 
   void precompute_check2equiv();
 
   void precompute_M2M();
 
-  void precompute_M2Lhelper();
-
-  void precompute_M2L();
+  void precompute_M2L(std::ofstream& file, std::vector<std::vector<int>>& parent2child);
 
   bool load_matrix();
 
-  void save_matrix();
+  void save_matrix(std::ofstream& file);
 
   void precompute();
 }//end namespace

--- a/include/precompute_helmholtz.h
+++ b/include/precompute_helmholtz.h
@@ -26,8 +26,6 @@ namespace exafmm_t {
 
   ComplexVec conjugate_transpose(ComplexVec& vec, int m, int n);
 
-  std::vector<std::vector<int>> map_matrix_index();
-
   void initialize_matrix();
 
   void precompute_check2equiv();

--- a/include/precompute_laplace.h
+++ b/include/precompute_laplace.h
@@ -24,8 +24,6 @@ namespace exafmm_t {
 
   RealVec transpose(RealVec& vec, int m, int n);
 
-  std::vector<std::vector<int>> map_matrix_index();
-
   void initialize_matrix();
 
   void precompute_check2equiv();

--- a/include/precompute_laplace.h
+++ b/include/precompute_laplace.h
@@ -24,15 +24,15 @@ namespace exafmm_t {
 
   RealVec transpose(RealVec& vec, int m, int n);
 
+  std::vector<std::vector<int>> map_matrix_index();
+
   void initialize_matrix();
 
   void precompute_check2equiv();
 
   void precompute_M2M();
 
-  void precompute_M2Lhelper();
-
-  void precompute_M2L();
+  void precompute_M2L(std::vector<std::vector<int>>& parent2child);
 
   bool load_matrix();
 

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -113,4 +113,27 @@ namespace exafmm_t {
     init_rel_coord(5, 5, 2, M2P_Type);
     init_rel_coord(5, 5, 2, P2L_Type);
   }
+
+  // Map indices of M2L_Type to indices of M2L_Helper_Type
+  std::vector<std::vector<int>> map_matrix_index() {
+    int num_coords = REL_COORD[M2L_Type].size();   // number of relative coords for M2L_Type
+    std::vector<std::vector<int>> parent2child(num_coords, std::vector<int>(NCHILD*NCHILD));
+#pragma omp parallel for
+    for(int i=0; i<num_coords; ++i) {
+      for(int j1=0; j1<NCHILD; ++j1) {
+        for(int j2=0; j2<NCHILD; ++j2) {
+          ivec3& parent_rel_coord = REL_COORD[M2L_Type][i];
+          ivec3  child_rel_coord;
+          child_rel_coord[0] = parent_rel_coord[0]*2 - (j1/1)%2 + (j2/1)%2;
+          child_rel_coord[1] = parent_rel_coord[1]*2 - (j1/2)%2 + (j2/2)%2;
+          child_rel_coord[2] = parent_rel_coord[2]*2 - (j1/4)%2 + (j2/4)%2;
+          int coord_hash = hash(child_rel_coord);
+          int child_rel_idx = HASH_LUT[M2L_Helper_Type][coord_hash];
+          int j = j2*NCHILD + j1;
+          parent2child[i][j] = child_rel_idx;
+        }
+      }
+    }
+    return parent2child;
+  }
 } // end namespace

--- a/src/precompute_helmholtz.cpp
+++ b/src/precompute_helmholtz.cpp
@@ -7,29 +7,6 @@ namespace exafmm_t {
   std::string FILE_NAME;
   bool IS_PRECOMPUTED = true;  // whether matrices are precomputed
 
-  // Map indices of M2L_Type to indices of M2L_Helper_Type
-  std::vector<std::vector<int>> map_matrix_index() {
-    int num_coords = REL_COORD[M2L_Type].size();   // number of relative coords for M2L_Type
-    std::vector<std::vector<int>> parent2child(num_coords, std::vector<int>(NCHILD*NCHILD));
-#pragma omp parallel for
-    for(int i=0; i<num_coords; ++i) {
-      for(int j1=0; j1<NCHILD; ++j1) {
-        for(int j2=0; j2<NCHILD; ++j2) {
-          ivec3& parent_rel_coord = REL_COORD[M2L_Type][i];
-          ivec3  child_rel_coord;
-          child_rel_coord[0] = parent_rel_coord[0]*2 - (j1/1)%2 + (j2/1)%2;
-          child_rel_coord[1] = parent_rel_coord[1]*2 - (j1/2)%2 + (j2/2)%2;
-          child_rel_coord[2] = parent_rel_coord[2]*2 - (j1/4)%2 + (j2/4)%2;
-          int coord_hash = hash(child_rel_coord);
-          int child_rel_idx = HASH_LUT[M2L_Helper_Type][coord_hash];
-          int j = j2*NCHILD + j1;
-          parent2child[i][j] = child_rel_idx;
-        }
-      }
-    }
-    return parent2child;
-  }
-
   void initialize_matrix() {
     matrix_UC2E_V.resize(MAXLEVEL+1);
     matrix_UC2E_U.resize(MAXLEVEL+1);

--- a/src/precompute_helmholtz.cpp
+++ b/src/precompute_helmholtz.cpp
@@ -4,16 +4,13 @@ namespace exafmm_t {
   std::vector<ComplexVec> matrix_UC2E_U, matrix_UC2E_V;
   std::vector<ComplexVec> matrix_DC2E_U, matrix_DC2E_V;
   std::vector<std::vector<ComplexVec>> matrix_M2M, matrix_L2L;
-  std::vector<std::vector<RealVec>> matrix_M2L_Helper;
-  std::vector<std::vector<AlignedVec>> matrix_M2L;
-  std::vector<std::vector<int>> parent2child;
   std::string FILE_NAME;
   bool IS_PRECOMPUTED = true;  // whether matrices are precomputed
 
   // Map indices of M2L_Type to indices of M2L_Helper_Type
-  void index_mapping(std::vector<std::vector<int>>& parent2child) {
+  std::vector<std::vector<int>> map_matrix_index() {
     int num_coords = REL_COORD[M2L_Type].size();   // number of relative coords for M2L_Type
-    parent2child.resize(num_coords, std::vector<int>(NCHILD*NCHILD));
+    std::vector<std::vector<int>> parent2child(num_coords, std::vector<int>(NCHILD*NCHILD));
 #pragma omp parallel for
     for(int i=0; i<num_coords; ++i) {
       for(int j1=0; j1<NCHILD; ++j1) {
@@ -30,19 +27,16 @@ namespace exafmm_t {
         }
       }
     }
+    return parent2child;
   }
 
   void initialize_matrix() {
-    int n1 = P * 2;
-    int n3 = n1 * n1 * n1;
-    size_t fft_size = n3 * 2 * NCHILD * NCHILD;
     matrix_UC2E_V.resize(MAXLEVEL+1);
     matrix_UC2E_U.resize(MAXLEVEL+1);
     matrix_DC2E_V.resize(MAXLEVEL+1);
     matrix_DC2E_U.resize(MAXLEVEL+1);
     matrix_M2M.resize(MAXLEVEL+1);
     matrix_L2L.resize(MAXLEVEL+1);
-    matrix_M2L.resize(MAXLEVEL);  // skip the last level
     for(int level = 0; level <= MAXLEVEL; level++) {
       matrix_UC2E_V[level].resize(NSURF*NSURF);
       matrix_UC2E_U[level].resize(NSURF*NSURF);
@@ -51,10 +45,6 @@ namespace exafmm_t {
       matrix_M2M[level].resize(REL_COORD[M2M_Type].size(), ComplexVec(NSURF*NSURF));
       matrix_L2L[level].resize(REL_COORD[L2L_Type].size(), ComplexVec(NSURF*NSURF));
     }
-    for(int level = 0; level < MAXLEVEL; level++) {
-      matrix_M2L[level].resize(REL_COORD[M2L_Type].size(), AlignedVec(fft_size));  // N3 by (2*NCHILD*NCHILD) matrix
-    }
-    index_mapping(parent2child);
   }
 
   // complex gemm by blas lib
@@ -149,9 +139,9 @@ namespace exafmm_t {
     for(int level = 0; level <= MAXLEVEL; level++) {
       RealVec parent_up_check_surf = surface(P, parent_coord, 2.95, level);
       real_t s = R0 * powf(0.5, level+1);
-      int numRelCoord = REL_COORD[M2M_Type].size();
+      int num_coords = REL_COORD[M2M_Type].size();
 #pragma omp parallel for
-      for(int i=0; i<numRelCoord; i++) {
+      for(int i=0; i<num_coords; i++) {
         ivec3& coord = REL_COORD[M2M_Type][i];
         real_t child_coord[3] = {parent_coord[0] + coord[0]*s,
                                  parent_coord[1] + coord[1]*s,
@@ -171,56 +161,57 @@ namespace exafmm_t {
     }
   }
 
-  void precompute_M2Lhelper() {
-    matrix_M2L_Helper.resize(MAXLEVEL+1);
+  void precompute_M2L(std::ofstream& file, std::vector<std::vector<int>>& parent2child) {
     int n1 = P * 2;
     int n3 = n1 * n1 * n1;
+    int fft_size = 2 * n3 * NCHILD * NCHILD;
+    std::vector<RealVec> matrix_M2L_Helper(REL_COORD[M2L_Helper_Type].size(), RealVec(2*n3));
+    std::vector<AlignedVec> matrix_M2L(REL_COORD[M2L_Type].size(), AlignedVec(fft_size));
     // create fftw plan
     ComplexVec fftw_in(n3);
     RealVec fftw_out(2*n3);
     int dim[3] = {2*P, 2*P, 2*P};
-    fft_plan plan = fft_plan_dft(3, dim, reinterpret_cast<fft_complex*>(&fftw_in[0]), 
-                                (fft_complex*)(&fftw_out[0]), FFTW_FORWARD, FFTW_ESTIMATE);
-    // evaluate DFTs of potentials at convolution grids
-    int numRelCoord = REL_COORD[M2L_Helper_Type].size();
-    RealVec r_trg(3, 0.0);
-    for(int l=0; l<=MAXLEVEL; l++) {
-      matrix_M2L_Helper[l].resize(numRelCoord);
-      #pragma omp parallel for
-      for(int i=0; i<numRelCoord; i++) {
+    fft_plan plan = fft_plan_dft(3, dim,
+                                reinterpret_cast<fft_complex*>(fftw_in.data()), 
+                                reinterpret_cast<fft_complex*>(fftw_out.data()),
+                                FFTW_FORWARD, FFTW_ESTIMATE);
+    // Precompute M2L matrix
+    RealVec trg_coord(3,0);
+    for(int l=1; l<MAXLEVEL+1; ++l) {
+      // compute DFT of potentials at convolution grids
+#pragma omp parallel for
+      for(int i=0; i<REL_COORD[M2L_Helper_Type].size(); i++) {
         real_t coord[3];
         for(int d=0; d<3; d++) {
           coord[d] = REL_COORD[M2L_Helper_Type][i][d] * R0 * powf(0.5, l-1);
         }
-        RealVec conv_coord = convolution_grid(coord, l);
-        ComplexVec conv_poten(n3);
-        kernel_matrix(&conv_coord[0], n3, &r_trg[0], 1, &conv_poten[0]);
-        matrix_M2L_Helper[l][i].resize(2*n3);
-        fft_execute_dft(plan, reinterpret_cast<fft_complex*>(&conv_poten[0]), (fft_complex*)(&matrix_M2L_Helper[l][i][0]));
+        RealVec conv_coord = convolution_grid(coord, l);   // convolution grid
+        ComplexVec conv_p(n3);   // potentials on convolution grid
+        kernel_matrix(conv_coord.data(), n3, trg_coord.data(), 1, conv_p.data());
+        fft_execute_dft(plan, reinterpret_cast<fft_complex*>(conv_p.data()),
+                              reinterpret_cast<fft_complex*>(matrix_M2L_Helper[i].data()));
       }
-    }
-    fft_destroy_plan(plan);
-  }
-
-  void precompute_M2L() {
-    int n1 = P * 2;
-    int n3 = n1 * n1 * n1;
-    int num_coords = REL_COORD[M2L_Type].size();
-    // copy from matrix_M2L_Helper to matrix_M2L
-    for(int l=0; l<MAXLEVEL; ++l) {
-      for(int i=0; i<num_coords; ++i) {
-        for(int j=0; j<NCHILD*NCHILD; j++) {       // loop over child's relative positions
+      // convert M2L_Helper to M2L, reorder to improve data locality
+#pragma omp parallel for
+      for(int i=0; i<REL_COORD[M2L_Type].size(); ++i) {
+        for(int j=0; j<NCHILD*NCHILD; j++) {   // loop over child's relative positions
           int child_rel_idx = parent2child[i][j];
           if (child_rel_idx != -1) {
-            for(int k=0; k<n3; k++) {                      // loop over frequencies
+            for(int k=0; k<n3; k++) {   // loop over frequencies
               int new_idx = k*(2*NCHILD*NCHILD) + 2*j;
-              matrix_M2L[l][i][new_idx+0] = matrix_M2L_Helper[l+1][child_rel_idx][k*2+0] / n3;   // real
-              matrix_M2L[l][i][new_idx+1] = matrix_M2L_Helper[l+1][child_rel_idx][k*2+1] / n3;   // imag
+              matrix_M2L[i][new_idx+0] = matrix_M2L_Helper[child_rel_idx][k*2+0] / n3;   // real
+              matrix_M2L[i][new_idx+1] = matrix_M2L_Helper[child_rel_idx][k*2+1] / n3;   // imag
             }
           }
         }
       }
+      // write to file
+      for(auto& vec : matrix_M2L) {
+        file.write(reinterpret_cast<char*>(vec.data()), fft_size*sizeof(real_t));
+      }
     }
+    // destroy fftw plan
+    fft_destroy_plan(plan);
   }
 
   bool load_matrix() {
@@ -263,12 +254,6 @@ namespace exafmm_t {
             file.read(reinterpret_cast<char*>(&vec[0]), size*sizeof(complex_t));
           }
         }
-        // M2L
-        for(int level = 0; level < MAXLEVEL; level++) {
-          for(auto & vec : matrix_M2L[level]) {
-            file.read(reinterpret_cast<char*>(&vec[0]), fft_size*sizeof(real_t));
-          }
-        }
         file.close();
         return true;
       } else {
@@ -279,9 +264,7 @@ namespace exafmm_t {
     }
   }
 
-  void save_matrix() {
-    std::remove(FILE_NAME.c_str());
-    std::ofstream file(FILE_NAME, std::ofstream::binary);
+  void save_matrix(std::ofstream& file) {
     // root radius R0
     file.write(reinterpret_cast<char*>(&R0), sizeof(real_t));
     // wavenumber WAVEK
@@ -301,15 +284,6 @@ namespace exafmm_t {
         file.write(reinterpret_cast<char*>(&vec[0]), size*sizeof(complex_t));
       }
     }
-    // M2L precompute data
-    int n1 = P * 2;
-    int n3 = n1 * n1 * n1;
-    size = n3 * 2 * NCHILD * NCHILD;
-    for(int level = 0; level < MAXLEVEL; level++) {
-      for(auto & vec : matrix_M2L[level]) {
-        file.write(reinterpret_cast<char*>(&vec[0]), size*sizeof(real_t));
-      }
-    }
   }
 
   void precompute() {
@@ -324,9 +298,12 @@ namespace exafmm_t {
     } else {
       precompute_check2equiv();
       precompute_M2M();
-      precompute_M2Lhelper();
-      precompute_M2L();
-      save_matrix();
+      std::remove(FILE_NAME.c_str());
+      std::ofstream file(FILE_NAME, std::ofstream::binary);
+      save_matrix(file);
+      auto parent2child = map_matrix_index();
+      precompute_M2L(file, parent2child);
+      file.close();
     }
   }
 }//end namespace

--- a/src/precompute_laplace.cpp
+++ b/src/precompute_laplace.cpp
@@ -8,29 +8,6 @@ namespace exafmm_t {
   std::string FILE_NAME;
   bool IS_PRECOMPUTED = true;  // whether matrices are precomputed
 
-  // Map indices of M2L_Type to indices of M2L_Helper_Type
-  std::vector<std::vector<int>> map_matrix_index() {
-    int num_coords = REL_COORD[M2L_Type].size();   // number of relative coords for M2L_Type
-    std::vector<std::vector<int>> parent2child(num_coords, std::vector<int>(NCHILD*NCHILD));
-#pragma omp parallel for
-    for(int i=0; i<num_coords; ++i) {
-      for(int j1=0; j1<NCHILD; ++j1) {
-        for(int j2=0; j2<NCHILD; ++j2) {
-          ivec3& parent_rel_coord = REL_COORD[M2L_Type][i];
-          ivec3  child_rel_coord;
-          child_rel_coord[0] = parent_rel_coord[0]*2 - (j1/1)%2 + (j2/1)%2;
-          child_rel_coord[1] = parent_rel_coord[1]*2 - (j1/2)%2 + (j2/2)%2;
-          child_rel_coord[2] = parent_rel_coord[2]*2 - (j1/4)%2 + (j2/4)%2;
-          int coord_hash = hash(child_rel_coord);
-          int child_rel_idx = HASH_LUT[M2L_Helper_Type][coord_hash];
-          int j = j2*NCHILD + j1;
-          parent2child[i][j] = child_rel_idx;
-        }
-      }
-    }
-    return parent2child;
-  }
-
   //! blas gemm with row major data
   void gemm(int m, int n, int k, real_t* A, real_t* B, real_t* C) {
     char transA = 'N', transB = 'N';


### PR DESCRIPTION
- Absorb precompute_M2L_Helper into precompute_M2L so that matrix_M2L_Helper turns to a local variable
- Use a dedicated function map_matrix_index() to assemble matrix_M2L from matrix_M2L_Helper
- For Helmholtz kernel, keep matrix_M2L for only one level in memory during precomputation and evaluate to save memory, now M2L kernel start with loading matrix of a specific level